### PR TITLE
reset activity category to show error message when not select

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ function clearInputValues() {
   activityInput.value = '';
   minutesInput.value = '';
   secondsInput.value = '';
+  activityCategory = undefined;
   removeColor();
 };
 


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug where the category when not selected would not throw an error

#### Where should the reviewer start?
start on the home page

#### How should this be manually tested?
click no category and click start activity.

#### Any background context you want to provide?
NA

#### Screenshots (if appropriate)
NA

#### Questions:
NA
